### PR TITLE
Style carousel as film strip

### DIFF
--- a/ccs-2.css
+++ b/ccs-2.css
@@ -425,8 +425,34 @@ body {
 
 .carousel-track-container {
     overflow: hidden;
-    border-radius: 0.5rem;
-    box-shadow: var(--shadow-elegant);
+    background: #000;
+    border: 8px solid #222;
+    border-radius: 4px;
+    padding: 20px 0;
+    position: relative;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+
+/* Agujeros de la cinta - arriba y abajo */
+.carousel-track-container::before,
+.carousel-track-container::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 20px;
+    background-image: radial-gradient(circle, #fff 25%, transparent 30%);
+    background-size: 40px 20px;
+    background-repeat: repeat-x;
+    opacity: 0.9;
+}
+
+.carousel-track-container::before {
+    top: -8px; /* alineado al borde superior */
+}
+
+.carousel-track-container::after {
+    bottom: -8px; /* alineado al borde inferior */
 }
 
 .carousel-track {
@@ -443,6 +469,8 @@ body {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    border: 4px solid #000;
+    border-radius: 2px;
 }
 
 .carousel-btn {


### PR DESCRIPTION
Add film-strip styling to the carousel to implement the requested design.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e5121d0-d266-40d2-9add-a506d0b75db3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e5121d0-d266-40d2-9add-a506d0b75db3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

