### PR TITLE
Set cover image from Pinterest

### DIFF
--- a/ccs-2.css
+++ b/ccs-2.css
@@ -153,7 +153,7 @@ body {
     width: 100%;
     height: 100vh;
     height: 100svh; /* soporta barras de navegador móviles */
-    background-image: url('https://images.unsplash.com/photo-1519741497674-611481863552?w=1920&h=1080&fit=crop&crop=center');
+    background-image: url('https://i.pinimg.com/originals/1X/K8/NT/NZJ/1XK8NTNZJ.jpg');
     background-size: cover;
     background-position: center;
     background-attachment: fixed;


### PR DESCRIPTION
Replace the hero section's background image with the user-provided Pinterest image.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c325817-3791-49ce-9eb2-7f53dd668b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c325817-3791-49ce-9eb2-7f53dd668b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

